### PR TITLE
Corrected date format string

### DIFF
--- a/App_Code/Saml.cs
+++ b/App_Code/Saml.cs
@@ -123,7 +123,7 @@ namespace OneLogin
                 this.accountSettings = accountSettings;
 
                 id = "_" + System.Guid.NewGuid().ToString();
-                issue_instant = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTH:mm:ssZ");
+                issue_instant = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
             }
 
             public string GetRequest(AuthRequestFormat format)


### PR DESCRIPTION
Date format string was using the code 'mm' instead of 'MM', hence inserting the minutes in the place of the month.
