### PR TITLE
Correct XML generation

### DIFF
--- a/App_Code/Saml.cs
+++ b/App_Code/Saml.cs
@@ -148,12 +148,13 @@ namespace OneLogin
 
                         xw.WriteStartElement("samlp", "RequestedAuthnContext", "urn:oasis:names:tc:SAML:2.0:protocol");
                         xw.WriteAttributeString("Comparison", "exact");
-                        xw.WriteEndElement();
 
                         xw.WriteStartElement("saml", "AuthnContextClassRef", "urn:oasis:names:tc:SAML:2.0:assertion");
                         xw.WriteString("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport");
                         xw.WriteEndElement();
-
+                        
+                        xw.WriteEndElement(); // RequestedAuthnContext
+                        
                         xw.WriteEndElement();
                     }
 


### PR DESCRIPTION
According to the SAML 2.0 specification, the AuthnContextClassRef needs to be inside the RequestedAuthnContext.