### PR TITLE
Update readme with new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Onelogin's is working on the release of a new toolkit for .NET, but it gonna tak
 - [ComponentSpace](http://www.componentspace.com/) (commercial)
 - [OIOSAML](https://digitaliser.dk/resource/2972745) (open source)
 - [ITfoxtec](http://itfoxtec.com/identitysaml2) (open source)
-- [Kentor](https://github.com/KentorIT/authservices) (open source)
+- [Sustainsys] (formerly Kentor) (https://github.com/Sustainsys/Saml2) (open source)
 - [Owin.Security.Saml](https://github.com/elerch/SAML2) (open source)


### PR DESCRIPTION
Update the readme file with the new name and link for the Kentor.AuthServices project. It has been transferred and is under rename to Sustainsys.Saml2.