### PR TITLE
Implement IDisposable for .Net 4.6

### DIFF
--- a/App_Code/Saml.cs
+++ b/App_Code/Saml.cs
@@ -21,7 +21,7 @@ namespace OneLogin
 {
     namespace Saml
     {
-        public class Certificate
+        public class Certificate : IDisposable
         {
             public X509Certificate2 cert;
 
@@ -46,9 +46,32 @@ namespace OneLogin
                 }
                 return bytes;
             }
+		#region Dispose added for .Net 4.6
+		bool disposed = false;
+		
+        public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+		
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+
+			if (disposing)
+			{
+				cert.Dispose();
+			}
+
+			disposed = true;
+		}
+		#endregion
+
         }
 
-	    public class Response
+	    public class Response: IDisposable
 	    {
             private XmlDocument xmlDoc;
             private AccountSettings accountSettings;
@@ -135,6 +158,10 @@ namespace OneLogin
                 XmlNode node = xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion/saml:Subject/saml:NameID",manager);
                 return node.InnerText;
             }
+            public void Dispose()
+		    {
+			    certificate.Dispose();
+		    }
 	    }
 
         public class AuthRequest

--- a/Consume.aspx.cs
+++ b/Consume.aspx.cs
@@ -22,17 +22,19 @@ public partial class _Default : System.Web.UI.Page
         // replace with an instance of the users account.
         AccountSettings accountSettings = new AccountSettings();
         
-        OneLogin.Saml.Response samlResponse = new Response(accountSettings);
-        samlResponse.LoadXmlFromBase64(Request.Form["SAMLResponse"]);
+        using (OneLogin.Saml.Response samlResponse = new Response(accountSettings))
+        {
+            samlResponse.LoadXmlFromBase64(Request.Form["SAMLResponse"]);
 
-        if (samlResponse.IsValid())
-        {
-            Response.Write("OK!");
-            Response.Write(samlResponse.GetNameID());
-        }
-        else
-        {
-            Response.Write("Failed");
+            if (samlResponse.IsValid())
+            {
+                Response.Write("OK!");
+                Response.Write(samlResponse.GetNameID());
+            }
+            else
+            {
+                Response.Write("Failed");
+            }
         }
     }
 }


### PR DESCRIPTION
Microsoft added IDisposable to X509Certificate in .Net Framework 4.6.  https://github.com/dotnet/docs/issues/6777 and https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509store

This suggested request adds IDisposable and the example for consuming it.